### PR TITLE
Bump the pip group across 1 directory with 2 updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ heroku3
 apscheduler
 motor 
 numpy
-pillow==9.5.0
+pillow==10.3.0
 psutil
 wget
 pyfiglet
@@ -40,7 +40,7 @@ spotipy
 tgcrypto
 telegraph
 unidecode
-yt-dlp==2024.3.10
+yt-dlp==2024.4.9
 youtube-search
 youtube-search-python
 gtts


### PR DESCRIPTION
Bumps the pip group with 2 updates in the / directory: [pillow](https://github.com/python-pillow/Pillow) and [yt-dlp](https://github.com/yt-dlp/yt-dlp).


Updates `pillow` from 9.5.0 to 10.3.0
- [Release notes](https://github.com/python-pillow/Pillow/releases)
- [Changelog](https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst)
- [Commits](https://github.com/python-pillow/Pillow/compare/9.5.0...10.3.0)

Updates `yt-dlp` from 2024.3.10 to 2024.4.9
- [Release notes](https://github.com/yt-dlp/yt-dlp/releases)
- [Changelog](https://github.com/yt-dlp/yt-dlp/blob/master/Changelog.md)
- [Commits](https://github.com/yt-dlp/yt-dlp/compare/2024.03.10...2024.04.09)

---
updated-dependencies:
- dependency-name: pillow dependency-type: direct:production dependency-group: pip
- dependency-name: yt-dlp dependency-type: direct:production dependency-group: pip ...